### PR TITLE
Explicitly convert exception message to string

### DIFF
--- a/lib/mongodb_logger/logger.rb
+++ b/lib/mongodb_logger/logger.rb
@@ -72,7 +72,7 @@ module MongodbLogger
 
       runtime = Benchmark.measure{ yield }.real if block_given?
     rescue Exception => e
-      add(3, e.message + "\n" + e.backtrace.join("\n"))
+      add(3, e.message.to_s + "\n" + e.backtrace.join("\n"))
       # log exceptions
       @mongo_record[:is_exception] = true
       # Reraise the exception for anyone else who cares


### PR DESCRIPTION
Turns out Ruby pre-1.9.3 has a bug that if an exception is passed a non-String object as the message, then it's not converted into a string, thus both `exception.message` and `exception.to_s` are non-strings.

See http://bugs.ruby-lang.org/issues/4736

Demonstration:

```
1.9.3p0 :002 > begin raise StandardError, [1,2]; rescue Exception=>e; puts e.message.inspect; end
"[1, 2]"

1.9.2p290 :001 > begin raise StandardError, [1,2]; rescue Exception=>e; puts e.message.inspect; end
[1, 2]
```

When `e.message` isn't a string, `mongodb_logger` raises an exception of its own. In my opinion this situation should be handled by the logger, even though it's not your bug.
