### PR TITLE
allow mounting assets under a non root path

### DIFF
--- a/lib/mongodb_logger/server/sprokets.rb
+++ b/lib/mongodb_logger/server/sprokets.rb
@@ -6,7 +6,7 @@ module MongodbLogger
   
   module AssetHelpers
     def asset_path(source)
-      "/assets/#{Assets.instance.find_asset(source).digest_path}" unless Assets.instance.find_asset(source).nil?
+      "#{request.env['SCRIPT_NAME']}/assets/#{Assets.instance.find_asset(source).digest_path}" unless Assets.instance.find_asset(source).nil?
     end
     def asset_data_uri(source)
       unless Assets.instance.find_asset(source).nil?


### PR DESCRIPTION
The assets prefix is hardcoded to /assets. This pull request makes this dependent on the path prefix. You can then integrate the web frontend into your Rack app like this:

``` ruby
map '/' do
  run SomeApp.new
end

MongodbLogger::ServerConfig.set_config "./config/mongodb_logger.yml"
map "/logger" do
  run MongodbLogger::Server.new
end

map "/logger/assets" do
  run Rack::Directory.new("assets/logger")
end
```
