### PR TITLE
Fix RailsLogger constructor

### DIFF
--- a/lib/mongodb_logger/rails_logger.rb
+++ b/lib/mongodb_logger/rails_logger.rb
@@ -4,4 +4,13 @@ module MongodbLogger
   else
     class RailsLogger < ActiveSupport::BufferedLogger; end
   end
+
+  RailsLogger.class_eval do
+    def initialize(path, level)
+      super(path)
+      @level = level
+      @logdev.instance_variable_set(:@shift_age, nil)
+      @logdev.instance_variable_set(:@shift_size, nil)
+    end
+  end
 end

--- a/lib/mongodb_logger/rails_logger.rb
+++ b/lib/mongodb_logger/rails_logger.rb
@@ -1,16 +1,14 @@
 module MongodbLogger
   if defined?(ActiveSupport::Logger)
-    class RailsLogger < ActiveSupport::Logger; end
+    class RailsLogger < ActiveSupport::Logger
+      def initialize(path, level)
+        super(path)
+        @level = level
+        @logdev.instance_variable_set(:@shift_age, nil)
+        @logdev.instance_variable_set(:@shift_size, nil)
+      end
+    end
   else
     class RailsLogger < ActiveSupport::BufferedLogger; end
-  end
-
-  RailsLogger.class_eval do
-    def initialize(path, level)
-      super(path)
-      @level = level
-      @logdev.instance_variable_set(:@shift_age, nil)
-      @logdev.instance_variable_set(:@shift_size, nil)
-    end
   end
 end


### PR DESCRIPTION
Please take Logger constructor under consideration.

Why (as I suppose) is this fix necessary? By default Rails creates logger with no @shift_age and @shift limit (both set to nil). With your gem, it creates one with default Ruby's [Logger](http://ruby-doc.org/stdlib-2.2.1/libdoc/logger/rdoc/Logger.html#method-c-new) values for these.

Track initializer logic through classes hierarchy:
1. https://github.com/le0pard/mongodb_logger/blob/master/lib/mongodb_logger/logger.rb#L42
2. https://github.com/le0pard/mongodb_logger/blob/master/lib/mongodb_logger/rails_logger.rb
3. http://api.rubyonrails.org/classes/ActiveSupport/Logger.html#method-c-new
4. http://edgeapi.rubyonrails.org/classes/ActiveSupport/BufferedLogger.html#method-c-new
5. http://ruby-doc.org/stdlib-2.2.1/libdoc/logger/rdoc/Logger.html#method-c-new
6. http://ruby-doc.org/stdlib-2.2.1/libdoc/logger/rdoc/Logger/LogDevice.html#method-c-new

And what is done in 1. is assigning logger level to logger's @shift_age.

Please tell me, if I'm wrong.