### PR TITLE
Support uncapped collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Doesn't support the Rails version below 3.
           username: postgres
           mongodb_logger:
             database: my_app               # required (the only required setting)
-            capsize: <%= 10.megabytes %>   # default: 250MB
+            capped: true                   # default: true  - warning: uncapped collections introduce the vulnerability that the size of the collection grows too high, exceeding all avaialble disk space
+            capsize: <%= 10.megabytes %>   # default: 250MB - ignored if capped is set to false
             host: localhost                # default: localhost
             port: 27017                    # default: 27017
             username: null                 # default: null, username for MongoDB Auth
@@ -291,5 +292,12 @@ Demo Sources: [https://github.com/le0pard/mongodb_logger_example_heroku](https:/
 
     >> collection.find({:request_time => {'$gt' => Time.utc(2010, 11, 18, 22, 59, 52)}})
 
+## Using Uncapped Collections as Storage
+
+MongoDB's capped collections are a safe choice for storing logs where expiration happens automatically after exceeding the provided `capsize` (first in first out expiration).
+
+Capped collections comes with a few limitations, one of them being that you cannot manually delete log entries. Switching to a `capped: false` configuration will store all log entries in an uncapped collection and remove the constraints of uncapped collections.
+
+**Warning:** If you choose to deploy mongodb_logger with an uncapped collection configuration, you should implement an alternative way of cleaning up log records (cron job or similar). Uncapped collections can grow indifinely in size and take up more disk space than you anticipated.
 
 Copyright (c) 2009-2014 Phil Burrows, CustomInk (based on https://github.com/customink/central_logger) and Leopard released under the MIT license

--- a/lib/mongodb_logger/adapters/base.rb
+++ b/lib/mongodb_logger/adapters/base.rb
@@ -31,7 +31,7 @@ module MongodbLogger
 
       def collection_stats_hash(stats)
         {
-          is_capped: (stats["capped"] && ([1, true].include?(stats["capped"]))),
+          is_capped: [1, true].include?(stats["capped"]),
           count: stats["count"].to_i,
           size: stats["size"].to_f,
           storageSize: stats["storageSize"].to_f,

--- a/lib/mongodb_logger/adapters/mongo.rb
+++ b/lib/mongodb_logger/adapters/mongo.rb
@@ -21,8 +21,10 @@ module MongodbLogger
       end
 
       def create_collection
-        @connection.create_collection(collection_name,
-          { capped: true, size: @configuration[:capsize].to_i })
+        @connection.create_collection(collection_name, {
+          capped: @configuration[:capped],
+          size: @configuration[:capsize].to_i # ignored if uncapped
+          })
       end
 
       def insert_log_record(record, options = {})

--- a/lib/mongodb_logger/adapters/moped.rb
+++ b/lib/mongodb_logger/adapters/moped.rb
@@ -22,7 +22,11 @@ module MongodbLogger
       end
 
       def create_collection
-        @connection.command(create: collection_name, capped: true, size:  @configuration[:capsize].to_i)
+        @connection.command({
+          create: collection_name,
+          capped: @configuration[:capped],
+          size: @configuration[:capsize].to_i # ignored if uncapped
+        })
       end
 
       def insert_log_record(record, options = {})

--- a/lib/mongodb_logger/logger.rb
+++ b/lib/mongodb_logger/logger.rb
@@ -101,10 +101,13 @@ module MongodbLogger
 
     def configure
       @db_configuration = {
-        host: 'localhost',
-        port: 27017,
-        capsize: DEFAULT_COLLECTION_SIZE,
-        ssl: false}.merge(resolve_config).with_indifferent_access
+          host: 'localhost',
+          port: 27017,
+          ssl: false,
+          capped: true,
+          capsize: DEFAULT_COLLECTION_SIZE
+        }.merge(resolve_config).
+          with_indifferent_access
       @db_configuration[:collection] ||= "#{app_env}_log"
       @db_configuration[:application_name] ||= resolve_application_name
       @db_configuration[:write_options] ||= { w: 0, wtimeout: 200 }

--- a/spec/factories/config/database_uncapped.yml
+++ b/spec/factories/config/database_uncapped.yml
@@ -1,0 +1,12 @@
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000
+  mongodb_logger:
+    database: uncapped_db
+    application_name: mongo_foo
+    capped: false
+    write_options:
+      w: 1
+      wtimeout: 200

--- a/spec/mongodb_logger_spec.rb
+++ b/spec/mongodb_logger_spec.rb
@@ -111,8 +111,23 @@ describe MongodbLogger::Logger do
         expect(@mongo_adapter.connection.collection_names.include?(@mongo_adapter.configuration['collection'])).to be_truthy
         # new capped collections are X MB + 5888 bytes, but don't be too strict in case that changes
         expect(@mongo_adapter.collection_stats[:storageSize]).to be < MongodbLogger::Logger::DEFAULT_COLLECTION_SIZE + 1.megabyte
+        expect(@mongo_adapter.collection_stats[:is_capped]).to be_truthy
       end
 
+    end
+
+    context "if collection is configured not to be capped" do
+      before do
+        setup_for_config(MongodbLogger::SpecHelper::DEFAULT_CONFIG_UNCAPPED, MongodbLogger::SpecHelper::DEFAULT_CONFIG)
+        @mongodb_logger.send(:connect)
+        @mongo_adapter = @mongodb_logger.mongo_adapter
+      end
+
+      it "creates a collection without cap" do
+        @mongodb_logger.send(:check_for_collection)
+        expect(@mongo_adapter.connection.collection_names.include?(@mongo_adapter.configuration['collection'])).to be_truthy
+        expect(@mongo_adapter.collection_stats[:is_capped]).to be_falsy
+      end
     end
 
     context "ssl" do

--- a/spec/support/mongodb_logger_helper.rb
+++ b/spec/support/mongodb_logger_helper.rb
@@ -7,6 +7,7 @@ module MongodbLogger::SpecHelper
   DEFAULT_CONFIG = "database.yml"
   DEFAULT_CONFIG_WITH_AUTH = "database_with_auth.yml"
   DEFAULT_CONFIG_CAPSIZE = "database_with_capsize.yml"
+  DEFAULT_CONFIG_UNCAPPED = "database_uncapped.yml"
   DEFAULT_CONFIG_WITH_URL = "database_with_url.yml"
   DEFAULT_CONFIG_WITH_SSL = "database_with_ssl.yml"
   DEFAULT_CONFIG_WITH_COLLECTION = "database_with_collection.yml"


### PR DESCRIPTION
Introduces a boolean `capped` option to db configuration. 

Capped collections does not support manual deletion, which we need in order to support expiration of log statements after a specific time. 

Do you see any unattended downsides to this?